### PR TITLE
Hot fix for AsymptoticLimit r value boundaries

### DIFF
--- a/condor/run_fits_disco.sh
+++ b/condor/run_fits_disco.sh
@@ -24,6 +24,9 @@ base_dir=`pwd`
 rMax="20"
 rMin="-20"
 
+rMinLim="0"
+rMaxLim="2"
+
 # Setup the working area on the remote job node.
 # Initialize a CMSSW environment and copy tar inputs into it
 source /cvmfs/cms.cern.ch/cmsset_default.sh
@@ -79,18 +82,18 @@ then
     echo "Running Asymptotic fits"
     if [ $asimov == 1 ]
     then
-        combine -M AsymptoticLimits ${fitOptions} --verbose 2 --rMin $rMin --rMax $rMax -t -1 --expectSignal=${inject} -n ${tagName}_AsymLimit_Asimov > log_${tagName}_Asymp.txt
+        combine -M AsymptoticLimits ${fitOptions} --verbose 2 --rMin $rMinLim --rMax $rMaxLim -t -1 --expectSignal=${inject} -n ${tagName}_AsymLimit_Asimov > log_${tagName}_Asymp.txt
     else
-        combine -M AsymptoticLimits ${fitOptions} --verbose 2 --rMin $rMin --rMax $rMax                                -n ${tagName}_AsymLimit > log_${tagName}_Asymp.txt
+        combine -M AsymptoticLimits ${fitOptions} --verbose 2 --rMin $rMinLim --rMax $rMaxLim                                -n ${tagName}_AsymLimit > log_${tagName}_Asymp.txt
     fi    
 
     # Calculate significance using Asimov data set and actual observation
     echo "Running Significance calculations"
     if [ $asimov == 1 ]
     then
-        combine -M Significance ${fitOptions} --verbose 2 --rMin $rMin --rMax $rMax -t -1 --expectSignal=${inject} -n ${tagName}_SignifExp_Asimov > log_${tagName}_Sign_Asimov.txt
+        combine -M Significance ${fitOptions} --verbose 2 --rMin $rMinLim --rMax $rMaxLim -t -1 --expectSignal=${inject} -n ${tagName}_SignifExp_Asimov > log_${tagName}_Sign_Asimov.txt
     else
-        combine -M Significance ${fitOptions} --verbose 2 --rMin $rMin --rMax $rMax                                -n ${tagName}_SignifExp > log_${tagName}_Sign.txt
+        combine -M Significance ${fitOptions} --verbose 2 --rMin $rMinLim --rMax $rMaxLim                                -n ${tagName}_SignifExp > log_${tagName}_Sign.txt
     fi
 fi
 

--- a/condor/run_fits_disco.sh
+++ b/condor/run_fits_disco.sh
@@ -91,9 +91,9 @@ then
     echo "Running Significance calculations"
     if [ $asimov == 1 ]
     then
-        combine -M Significance ${fitOptions} --verbose 2 --rMin $rMinLim --rMax $rMaxLim -t -1 --expectSignal=${inject} -n ${tagName}_SignifExp_Asimov > log_${tagName}_Sign_Asimov.txt
+        combine -M Significance ${fitOptions} --verbose 2 --rMin $rMin --rMax $rMax -t -1 --expectSignal=${inject} -n ${tagName}_SignifExp_Asimov > log_${tagName}_Sign_Asimov.txt
     else
-        combine -M Significance ${fitOptions} --verbose 2 --rMin $rMinLim --rMax $rMaxLim                                -n ${tagName}_SignifExp > log_${tagName}_Sign.txt
+        combine -M Significance ${fitOptions} --verbose 2 --rMin $rMin --rMax $rMax                                -n ${tagName}_SignifExp > log_${tagName}_Sign.txt
     fi
 fi
 


### PR DESCRIPTION
rMin and rMax need to be adjusted when running fits to find limits. The values have been shifted from -20 and 20 to 0 and 2. This should match the prescription in the combine documentation and provide more accurate results